### PR TITLE
switch base of buildimage to ubuntu noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #      - initial API and implementation and/or initial documentation
 # *******************************************************************************/
 
-FROM buildpack-deps:lunar
+FROM buildpack-deps:noble
 
 RUN set -eux; \
 	apt-get update; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 		lcov \
 		libmbedtls-dev \
 		libboost-all-dev \
+  		libpcap-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hoping to resolve https://github.com/eclipse-4diac/4diac-forte/issues/287 with this pull request:

The update sites for ubuntu lunar have been removed from the mirrors. Switch the base image to a long-term version of ubuntu to avoid similar problems in the near future